### PR TITLE
feat(@fe-base/react): If, If 유닛테스트

### DIFF
--- a/packages/@fe-base/react/src/components/If/index.test.tsx
+++ b/packages/@fe-base/react/src/components/If/index.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { If } from "./index";
+
+describe("If", () => {
+  it("조건이 true이면 trueRender를 렌더링한다", () => {
+    render(<If condition={true} trueRender={<div>true</div>} />);
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+
+  it("조건이 false이면 falseRender를 렌더링한다", () => {
+    render(<If condition={false} falseRender={<div>false</div>} />);
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 0이 아닌 숫자이면 trueRender를 렌더링한다", () => {
+    render(<If condition={1} trueRender={<div>true</div>} />);
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+
+  it("조건이 0이면 falseRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={0}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 빈 문자열이 아닌 문자열이면 trueRender를 렌더링한다", () => {
+    render(<If condition={"test"} trueRender={<div>true</div>} />);
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+
+  it("조건이 빈 문자열이면 falseRender를 렌더링한다", () => {
+    render(<If condition={""} falseRender={<div>false</div>} />);
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 null이면 falseRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={null}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 undefined이면 falseRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={undefined}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 NaN이면 falseRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={NaN}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("false")).toBeDefined();
+    expect(screen.queryByText("true")).toBeNull();
+  });
+
+  it("조건이 Infinity이면 trueRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={Infinity}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+
+  it("조건이 -Infinity이면 trueRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={-Infinity}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+
+  it("조건이 객체이면 trueRender를 렌더링한다", () => {
+    render(
+      <If
+        condition={{}}
+        trueRender={<div>true</div>}
+        falseRender={<div>false</div>}
+      />
+    );
+    expect(screen.getByText("true")).toBeDefined();
+    expect(screen.queryByText("false")).toBeNull();
+  });
+});

--- a/packages/@fe-base/react/src/components/If/index.tsx
+++ b/packages/@fe-base/react/src/components/If/index.tsx
@@ -1,0 +1,18 @@
+interface IfProps {
+  condition: boolean | unknown;
+  trueRender?: React.ReactNode;
+  falseRender?: React.ReactNode;
+}
+
+/**
+ *
+ * @param condition - 조건
+ * @param trueRender - 조건이 true일 때 렌더링할 컴포넌트
+ * @param falseRender - 조건이 false일 때 렌더링할 컴포넌트
+ * @returns 렌더링할 컴포넌트(trueRender or falseRender)
+ */
+export function If({ condition, trueRender, falseRender }: IfProps) {
+  const conditionFlag = !!condition;
+
+  return conditionFlag ? trueRender : falseRender;
+}


### PR DESCRIPTION
## Summary

- 조건식이 불린·숫자·문자열·객체 등 어떤 타입이든 받아 일반적인 truthy/falsy 규칙으로 분기를 처리하는 If 컴포넌트를 제공
- true/false 분기에서 필요한 렌더링만 전달하면 되고, 나머지는 생략 가능하도록 props를 옵셔널화
- truthy/falsy 입력에 대해 기대한 분기 렌더 테스트

## Example
```js
<If
  condition={user?.isLoggedIn}
  trueRender={<Dashboard />}
  falseRender={<Login />}
/>

<If
  condition={cartItems.length}
  trueRender={<CheckoutButton />}
/>

<If
  condition={null}
  falseRender={<EmptyState />}
/>
```
