### PR TITLE
feat(@fe-base/hooks): useToggle, useToggle 유닛테스트

### DIFF
--- a/packages/@fe-base/hooks/src/index.ts
+++ b/packages/@fe-base/hooks/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./useToggle";

--- a/packages/@fe-base/hooks/src/useToggle.test.ts
+++ b/packages/@fe-base/hooks/src/useToggle.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useToggle } from "./useToggle";
+
+describe("useToggle", () => {
+  it("기본값으로 false를 사용한다", () => {
+    const { result } = renderHook(() => useToggle());
+    expect(result.current.value).toBe(false);
+  });
+
+  it("초깃값을 true로 설정할 수 있다", () => {
+    const { result } = renderHook(() => useToggle(true));
+    expect(result.current.value).toBe(true);
+  });
+
+  it("toggle을 호출하면 값을 반전한다", () => {
+    const { result } = renderHook(() => useToggle());
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.value).toBe(true);
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.value).toBe(false);
+  });
+
+  it("toggle에 boolean을 넘기면 해당 값으로 고정한다", () => {
+    const { result } = renderHook(() => useToggle());
+
+    act(() => {
+      result.current.toggle(true);
+    });
+    expect(result.current.value).toBe(true);
+
+    act(() => {
+      result.current.toggle(false);
+    });
+    expect(result.current.value).toBe(false);
+  });
+
+  it("setTrue/setFalse 헬퍼가 값을 설정한다", () => {
+    const { result } = renderHook(() => useToggle());
+
+    act(() => result.current.setTrue());
+    expect(result.current.value).toBe(true);
+
+    act(() => result.current.setFalse());
+    expect(result.current.value).toBe(false);
+  });
+});

--- a/packages/@fe-base/hooks/src/useToggle.ts
+++ b/packages/@fe-base/hooks/src/useToggle.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from "react";
+
+export type UseToggleReturn = {
+  value: boolean;
+  toggle: (nextValue?: boolean) => void;
+  setTrue: () => void;
+  setFalse: () => void;
+};
+
+/**
+ * boolean 상태를 편리하게 관리하는 커스텀 훅
+ *
+ * @param initialValue - 초기 boolean 값 (기본값: false)
+ * @returns 현재 값과 상태 변경 함수들을 포함한 객체
+ *
+ * @example
+ * ```tsx
+ * function Modal() {
+ *   const { value: isOpen, toggle, setTrue, setFalse } = useToggle(false);
+ *
+ *   return (
+ *     <>
+ *       <button onClick={setTrue}>열기</button>
+ *       <button onClick={toggle}>토글</button>
+ *       {isOpen && (
+ *         <div className="modal">
+ *           <button onClick={setFalse}>닫기</button>
+ *         </div>
+ *       )}
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useToggle(initialValue = false): UseToggleReturn {
+  const [value, setValue] = useState(initialValue);
+
+  const toggle = useCallback((nextValue?: boolean) => {
+    setValue((prev) => (typeof nextValue === "boolean" ? nextValue : !prev));
+  }, []);
+
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
+
+  return { value, toggle, setTrue, setFalse };
+}


### PR DESCRIPTION
## Issue
close #10 

## Summary
`boolean` 상태 관리를 편리하게 할 수 있는 `useToggle` 커스텀 훅
- `toggle()`: 값 반전 또는 특정 값으로 설정
- `setTrue()`/`setFalse()`: 명시적인 값 설정 헬퍼
- 모달, 사이드바, 아코디언 등 booelan 기반 상태 관리에 유용하게 사용 가능

## Example
```jsx
// 모달 사용 (기본)
function Modal() {
  const { value: isOpen, toggle, setTrue, setFalse } = useToggle(false);

  return (
    <>
      <button onClick={setTrue}>열기</button>
      <button onClick={toggle}>토글</button>
      {isOpen && <div className="modal">...</div>}
    </>
  );
}


// 사이드바 사용 (초깃값 지정)
function Sidebar() {
  const { value: isExpanded, toggle } = useToggle(true);
  
  return (
    <aside className={isExpanded ? "expanded" : "collapsed"}>
      <button onClick={toggle}>메뉴</button>
    </aside>
  );
}

// 아코디언 사용 (특정 값으로 설정)
function Accordion() {
  const { value: isOpen, toggle } = useToggle();
  
  const handleClick = (forceOpen: boolean) => {
    toggle(forceOpen); // true/false로 직접 설정
  };
  
  return <div onClick={() => toggle()}>...</div>;
}
```